### PR TITLE
Completed support for multiple gamepad devices

### DIFF
--- a/include/uspi.h
+++ b/include/uspi.h
@@ -141,13 +141,11 @@ int USPiGamePadAvailable (void);
 #define MAX_AXIS    6
 #define MAX_HATS    6
 
-typedef struct USPiGamePadState {
-    unsigned short idVendor;
-    unsigned short idProduct;
-    unsigned short idVersion;
-
+typedef struct USPiGamePadState
+{
     int naxes;
-    struct {
+    struct
+    {
         int value;
         int minimum;
         int maximum;
@@ -164,7 +162,7 @@ USPiGamePadState;
 // returns 0 on failure
 const USPiGamePadState *USPiGamePadGetStatus (unsigned nDeviceIndex);		// nDeviceIndex is 0-based
 
-typedef void TGamePadStatusHandler (const USPiGamePadState *pGamePadState);
+typedef void TGamePadStatusHandler (unsigned nDeviceIndex, const USPiGamePadState *pGamePadState);
 void USPiGamePadRegisterStatusHandler (TGamePadStatusHandler *pStatusHandler);
 
 //

--- a/include/uspi/usbgamepad.h
+++ b/include/uspi/usbgamepad.h
@@ -28,13 +28,10 @@
 #include <uspi/types.h>
 #include <uspi.h>
 
-#define BOOT_REPORT_SIZE	8
-
-typedef void TGamePadStatusHandler (const USPiGamePadState *pGamepadState);
-
 typedef struct TUSBGamePadDevice
 {
 	TUSBDevice m_USBDevice;
+	unsigned m_nDeviceIndex;
 
 	u8 m_ucInterfaceNumber;
 	u8 m_ucAlternateSetting;

--- a/lib/uspilibrary.c
+++ b/lib/uspilibrary.c
@@ -3,7 +3,7 @@
 //
 // USPi - An USB driver for Raspberry Pi written in C
 // Copyright (C) 2014  R. Stange <rsta2@o2online.de>
-// 
+//
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
 // the Free Software Foundation, either version 3 of the License, or
@@ -52,7 +52,7 @@ int USPiInitialize (void)
 	}
 
 	s_pLibrary->pUKBD1 = (TUSBKeyboardDevice *) DeviceNameServiceGetDevice (DeviceNameServiceGet (), "ukbd1", FALSE);
-	
+
 	s_pLibrary->pUMouse1 = (TUSBMouseDevice *) DeviceNameServiceGetDevice (DeviceNameServiceGet (), "umouse1", FALSE);
 
 	for (unsigned i = 0; i < MAX_DEVICES; i++)
@@ -151,7 +151,7 @@ int USPiMassStorageDeviceRead (unsigned long long ullOffset, void *pBuffer, unsi
 	{
 		return -1;
 	}
-	
+
 	if (USBBulkOnlyMassStorageDeviceSeek (s_pLibrary->pUMSD[nDeviceIndex], ullOffset) != ullOffset)
 	{
 		return -1;
@@ -228,15 +228,14 @@ void USPiGamePadRegisterStatusHandler (TGamePadStatusHandler *pStatusHandler)
 {
 	assert (s_pLibrary != 0);
 
-	for (unsigned i = 0; i < MAX_DEVICES; i++)
-	{
-		if (s_pLibrary->pUPAD[i] == 0)
-		{
-			break;
-		}
-
-		USBGamePadDeviceRegisterStatusHandler (s_pLibrary->pUPAD[i], pStatusHandler);
-	}
+    unsigned i;
+    for (i = 0; i < MAX_DEVICES; i++)
+    {
+        if (s_pLibrary->pUPAD[i] != 0)
+        {
+            USBGamePadDeviceRegisterStatusHandler (s_pLibrary->pUPAD[i], pStatusHandler);
+        }
+    }
 }
 
 const USPiGamePadState *USPiGamePadGetStatus (unsigned nDeviceIndex)
@@ -248,7 +247,7 @@ const USPiGamePadState *USPiGamePadGetStatus (unsigned nDeviceIndex)
 	{
 		return 0;
 	}
-	
+
 	USBGamePadDeviceGetReport (s_pLibrary->pUPAD[nDeviceIndex]);
 
 	return &s_pLibrary->pUPAD[nDeviceIndex]->m_State;

--- a/sample/gamepad/main.c
+++ b/sample/gamepad/main.c
@@ -9,11 +9,11 @@
 
 static const char FromSample[] = "sample";
 
-static void GamePadStatusHandler (const USPiGamePadState *pState)
+static void GamePadStatusHandler (unsigned int nDeviceIndex, const USPiGamePadState *pState)
 {
 	TString Msg;
 	String (&Msg);
-	StringFormat (&Msg, "GamePad: Buttons 0x%X", pState->buttons);
+	StringFormat (&Msg, "GamePad %u: Buttons 0x%X", nDeviceIndex + 1, pState->buttons);
 
 	TString Value;
 	String (&Value);


### PR DESCRIPTION
Added deviceIndex to status handler callback
Removed manufacturer/product/device values from gamepad state structure,
obsoleted by USPiDeviceGetInformation
Added PS3 GamePad specific activation messages
Better calculation of HID report size
