### PR TITLE
Support framebuffers where pitch != width * bytes per pixel

### DIFF
--- a/env/include/uspienv/screen.h
+++ b/env/include/uspienv/screen.h
@@ -77,6 +77,7 @@ typedef struct TScreenDevice
 	TCharGenerator	 m_CharGen;
 	TScreenColor  	*m_pBuffer;
 	unsigned	 m_nSize;
+	unsigned	 m_nPitch;
 	unsigned	 m_nWidth;
 	unsigned	 m_nHeight;
 	unsigned	 m_nUsedHeight;


### PR DESCRIPTION
I have a display where the pitch == width * bytes per pixel invariant doesn't hold (pitch == 1376, width * bytes per pixel = 1360), so I couldn't use any of the USPi samples out of the box and had to struggle a bit to figure out why.  I eventually discovered the problem and wrote this patch, and am now able to use the samples with my display.

I'm not sure what assumptions about alignment, if any, can be made about framebuffers with arbitrary pitch, so this patch is written as conservatively as possible.  This does have the disadvantage of noticeably degrading the performance of scrolling, because it meant I needed to replace the memcpyblk() in ScreenDeviceScroll() with a normal memcpy().  If this degradation is unacceptable I'd be happy to rework the patch to try and do something more clever