### PR TITLE
Add support for the USB-MIDI device class.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ USPi
 Overview
 --------
 
-USPi is a bare metal USB driver for the Raspberry Pi written in C. It was ported from the Circle USB library. Using C allows it to be used from bare metal C code for the Raspberry Pi. Like the Circle USB library it supports control (synchronous), bulk and interrupt (synchronous and asynchronous) transfers. Function drivers are available for USB keyboards, mice, gamepads, mass storage devices (e.g. USB flash devices) and the on-board Ethernet controller. USPi should run on all existing Raspberry Pi models.
+USPi is a bare metal USB driver for the Raspberry Pi written in C. It was ported from the Circle USB library. Using C allows it to be used from bare metal C code for the Raspberry Pi. Like the Circle USB library it supports control (synchronous), bulk and interrupt (synchronous and asynchronous) transfers. Function drivers are available for USB keyboards, mice, MIDI instruments, gamepads, mass storage devices (e.g. USB flash devices) and the on-board Ethernet controller. USPi should run on all existing Raspberry Pi models.
 
 USPi comes with an environment library (int the *env/* subdirectory) which provides all required functions to get USPi running. Furthermore there are some sample programs (in the *sample/* subdirectory) which demonstrate the use of USPi and which rely on the environment library. If you provide your own application and environment both are not needed.
 

--- a/include/uspi.h
+++ b/include/uspi.h
@@ -169,6 +169,17 @@ typedef void TGamePadStatusHandler (unsigned nDeviceIndex, const USPiGamePadStat
 void USPiGamePadRegisterStatusHandler (TGamePadStatusHandler *pStatusHandler);
 
 //
+// MIDI device
+//
+
+// returns != 0 if a MIDI device is available
+int USPiMIDIAvailable (void);
+
+// The packet handler is called once for each MIDI event packet received from the device.
+typedef void TUSPiMIDIPacketHandler (unsigned nCable, unsigned nLength, u8 *pPacket);
+void USPiMIDIRegisterPacketHandler (TUSPiMIDIPacketHandler *pPacketHandler);
+
+//
 // USB device information
 //
 

--- a/include/uspi/usb.h
+++ b/include/uspi/usb.h
@@ -85,6 +85,8 @@ PACKED TSetupData;
 #define DESCRIPTOR_STRING		3
 #define DESCRIPTOR_INTERFACE		4
 #define DESCRIPTOR_ENDPOINT		5
+#define DESCRIPTOR_CS_INTERFACE	36
+#define DESCRIPTOR_CS_ENDPOINT	37
 
 #define DESCRIPTOR_INDEX_DEFAULT	0
 
@@ -150,6 +152,31 @@ typedef struct
 }
 PACKED TUSBEndpointDescriptor;
 
+// Audio class Endpoint Descriptor
+typedef struct
+{
+	unsigned char	bLength;
+	unsigned char	bDescriptorType;
+	unsigned char	bEndpointAddress;
+	unsigned char	bmAttributes;
+	unsigned short	wMaxPacketSize;
+	unsigned char	bInterval;
+	unsigned char	bRefresh;
+	unsigned char	bSynchAddress;
+}
+PACKED TUSBAudioEndpointDescriptor;
+
+// MIDI-streaming class-specific Endpoint Descriptor
+typedef struct
+{
+	unsigned char	bLength;
+	unsigned char	bDescriptorType;
+	unsigned char	bDescriptorSubType;
+	unsigned char	bNumEmbMIDIJack;
+	unsigned char	bAssocJackIDs[];
+}
+PACKED TUSBMIDIStreamingEndpointDescriptor;
+
 // Descriptor union
 typedef union
 {
@@ -160,9 +187,11 @@ typedef union
 	}
 	Header;
 
-	TUSBConfigurationDescriptor	Configuration;
-	TUSBInterfaceDescriptor		Interface;
-	TUSBEndpointDescriptor		Endpoint;
+	TUSBConfigurationDescriptor			Configuration;
+	TUSBInterfaceDescriptor				Interface;
+	TUSBEndpointDescriptor				Endpoint;
+	TUSBAudioEndpointDescriptor			AudioEndpoint;
+	TUSBMIDIStreamingEndpointDescriptor	MIDIStreamingEndpoint;
 }
 PACKED TUSBDescriptor;
 

--- a/include/uspi/usbmidi.h
+++ b/include/uspi/usbmidi.h
@@ -1,0 +1,52 @@
+//
+// usbmidi.h
+//
+// USPi - An USB driver for Raspberry Pi written in C
+// Copyright (C) 2016  R. Stange <rsta2@o2online.de>
+// Copyright (C) 2016  J. Otto <joshua.t.otto@gmail.com>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+#ifndef _usbmidi_h
+#define _usbmidi_h
+
+#include <uspi/usbdevice.h>
+#include <uspi/usbendpoint.h>
+#include <uspi/usbrequest.h>
+#include <uspi/types.h>
+
+typedef void TMIDIPacketHandler(unsigned nCable, unsigned nLength, u8 *pPacket);
+
+typedef struct TUSBMIDIDevice
+{
+	TUSBDevice m_USBDevice;
+
+	TUSBEndpoint *m_pEndpointIn;
+
+	TMIDIPacketHandler *m_pPacketHandler;
+
+	TUSBRequest *m_pURB;
+	u16 m_usBufferSize;
+	u8 *m_pPacketBuffer;
+}
+TUSBMIDIDevice;
+
+void USBMIDIDevice (TUSBMIDIDevice *pThis, TUSBDevice *pDevice);
+void _CUSBMIDIDevice (TUSBMIDIDevice *pThis);
+
+boolean USBMIDIDeviceConfigure (TUSBDevice *pUSBDevice);
+
+void USBMIDIDeviceRegisterPacketHandler (TUSBMIDIDevice *pThis, TMIDIPacketHandler *pPacketHandler);
+
+#endif

--- a/include/uspi/uspilibrary.h
+++ b/include/uspi/uspilibrary.h
@@ -26,6 +26,7 @@
 #include <uspi/usbmouse.h>
 #include <uspi/usbgamepad.h>
 #include <uspi/usbmassdevice.h>
+#include <uspi/usbmidi.h>
 #include <uspi/smsc951x.h>
 
 #ifdef __cplusplus
@@ -43,6 +44,7 @@ typedef struct TUSPiLibrary
 	TUSBBulkOnlyMassStorageDevice	*pUMSD[MAX_DEVICES];
 	TSMSC951xDevice			*pEth0;
 	TUSBGamePadDevice       	*pUPAD[MAX_DEVICES];
+	TUSBMIDIDevice			*pMIDI1;
 }
 TUSPiLibrary;
 

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -25,7 +25,7 @@ OBJS	= uspilibrary.o \
 	  usbmassdevice.o \
 	  dwhciframeschednper.o dwhciframeschedper.o keymap.o usbkeyboard.o \
 	  dwhcirootport.o usbmouse.o \
-	  dwhciframeschednsplit.o usbgamepad.o synchronize.o usbstring.o
+	  dwhciframeschednsplit.o usbgamepad.o synchronize.o usbstring.o usbmidi.o
 
 libuspi.a: $(OBJS)
 	rm -f libuspi.a

--- a/lib/usbconfigparser.c
+++ b/lib/usbconfigparser.c
@@ -55,6 +55,7 @@ void USBConfigurationParser (TUSBConfigurationParser *pThis, const void *pBuffer
 
 	const TUSBDescriptor *pCurrentPosition = pThis->m_pBuffer;
 	u8 ucLastDescType = 0;
+	boolean bInAudioInterface = FALSE;
 	while (SKIP_BYTES (pCurrentPosition, 2) < pThis->m_pEndPosition)
 	{
 		u8 ucDescLen  = pCurrentPosition->Header.bLength;
@@ -86,6 +87,7 @@ void USBConfigurationParser (TUSBConfigurationParser *pThis, const void *pBuffer
 				return;
 			}
 			ucExpectedLen = sizeof (TUSBInterfaceDescriptor);
+			bInAudioInterface = pCurrentPosition->Interface.bInterfaceClass == 0x01; // Audio class
 			break;
 
 		case DESCRIPTOR_ENDPOINT:
@@ -95,7 +97,7 @@ void USBConfigurationParser (TUSBConfigurationParser *pThis, const void *pBuffer
 				pThis->m_pErrorPosition = pCurrentPosition;
 				return;
 			}
-			ucExpectedLen = sizeof (TUSBEndpointDescriptor);
+			ucExpectedLen = bInAudioInterface ? sizeof (TUSBAudioEndpointDescriptor) : sizeof (TUSBEndpointDescriptor);
 			break;
 
 		default:

--- a/lib/usbdevicefactory.c
+++ b/lib/usbdevicefactory.c
@@ -27,6 +27,7 @@
 #include <uspi/usbkeyboard.h>
 #include <uspi/usbmouse.h>
 #include <uspi/usbgamepad.h>
+#include <uspi/usbmidi.h>
 #include <uspi/smsc951x.h>
 
 TUSBDevice *GetDevice (TUSBDevice *pParent, TString *pName);
@@ -97,6 +98,13 @@ TUSBDevice *GetDevice (TUSBDevice *pParent, TString *pName)
         USBGamePadDevice (pDevice, pParent);
         pResult = (TUSBDevice *) pDevice;
     }
+	else if (StringCompare (pName, "int1-3-0") == 0)
+	{
+		TUSBMIDIDevice *pDevice = (TUSBMIDIDevice *) malloc (sizeof (TUSBMIDIDevice));
+		assert (pDevice != 0);
+		USBMIDIDevice (pDevice, pParent);
+		pResult = (TUSBDevice *)pDevice;
+	}
 	// new devices follow
 
 	if (pResult != 0)

--- a/lib/usbendpoint.c
+++ b/lib/usbendpoint.c
@@ -43,7 +43,7 @@ void USBEndpoint2 (TUSBEndpoint *pThis, TUSBDevice *pDevice, const TUSBEndpointD
 	assert (pThis->m_pDevice != 0);
 
 	assert (pDesc != 0);
-	assert (pDesc->bLength == sizeof *pDesc);
+	assert (pDesc->bLength == sizeof *pDesc || pDesc->bLength == sizeof (TUSBAudioEndpointDescriptor));
 	assert (pDesc->bDescriptorType == DESCRIPTOR_ENDPOINT);
 
 	switch (pDesc->bmAttributes & 0x03)

--- a/lib/usbmidi.c
+++ b/lib/usbmidi.c
@@ -1,0 +1,221 @@
+//
+// usbmidi.c
+//
+// USPi - An USB driver for Raspberry Pi written in C
+// Copyright (C) 2016  R. Stange <rsta2@o2online.de>
+// Copyright (C) 2016  J. Otto <joshua.t.otto@gmail.com>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+// Refer to "Universal Serial Bus Device Class Specification for MIDI Devices"
+
+#include <uspi/usbmidi.h>
+#include <uspi/usbhostcontroller.h>
+#include <uspi/devicenameservice.h>
+#include <uspi/assert.h>
+#include <uspios.h>
+
+static const char FromMIDI[] = "umidi";
+
+static unsigned s_nDeviceNumber = 1;
+
+static boolean USBMIDIDeviceStartRequest (TUSBMIDIDevice *pThis);
+static void USBMIDIDeviceCompletionRoutine (TUSBRequest *pURB, void *pParam, void *pContext);
+
+// This handy table from the Linux driver encodes the mapping between MIDI
+// packet Code Index Number values and encapsulated packet lengths.
+static const unsigned cin_to_length[] = {
+	0, 0, 2, 3, 3, 1, 2, 3, 3, 3, 3, 3, 2, 2, 3, 1
+};
+
+#define EVENT_PACKET_SIZE 4
+
+void USBMIDIDevice (TUSBMIDIDevice *pThis, TUSBDevice *pDevice)
+{
+	assert (pThis != 0);
+
+	USBDeviceCopy (&pThis->m_USBDevice, pDevice);
+	pThis->m_USBDevice.Configure = USBMIDIDeviceConfigure;
+
+	pThis->m_pEndpointIn = 0;
+	pThis->m_pPacketHandler = 0;
+	pThis->m_pURB = 0;
+	pThis->m_pPacketBuffer = 0;
+}
+
+void _CUSBMIDIDevice (TUSBMIDIDevice *pThis)
+{
+	assert (pThis != 0);
+
+	if (pThis->m_pPacketBuffer != 0)
+	{
+		free (pThis->m_pPacketBuffer);
+		pThis->m_pPacketBuffer = 0;
+	}
+
+	if (pThis->m_pEndpointIn != 0)
+	{
+		_USBEndpoint (pThis->m_pEndpointIn);
+		free (pThis->m_pEndpointIn);
+		pThis->m_pEndpointIn = 0;
+	}
+
+	_USBDevice (&pThis->m_USBDevice);
+}
+
+boolean USBMIDIDeviceConfigure (TUSBDevice *pUSBDevice)
+{
+	TUSBMIDIDevice *pThis = (TUSBMIDIDevice *)pUSBDevice;
+	assert (pThis != 0);
+
+	TUSBConfigurationDescriptor *pConfDesc =
+		(TUSBConfigurationDescriptor *) USBDeviceGetDescriptor (&pThis->m_USBDevice, DESCRIPTOR_CONFIGURATION);
+	if (   pConfDesc == 0
+		|| pConfDesc->bNumInterfaces < 1)
+	{
+		USBDeviceConfigurationError (&pThis->m_USBDevice, FromMIDI);
+
+		return FALSE;
+	}
+
+	TUSBInterfaceDescriptor *pInterfaceDesc;
+	while ((pInterfaceDesc = (TUSBInterfaceDescriptor *) USBDeviceGetDescriptor (&pThis->m_USBDevice, DESCRIPTOR_INTERFACE)) != 0)
+	{
+		if (   pInterfaceDesc->bNumEndpoints		==  0
+			|| pInterfaceDesc->bInterfaceClass		!= 0x01  // Audio class
+			|| pInterfaceDesc->bInterfaceSubClass	!= 0x03  // MIDI streaming
+			|| pInterfaceDesc->bInterfaceProtocol	!= 0x00) // unused, must be 0
+		{
+			continue;
+		}
+
+		// Our strategy for now is simple: we'll take the first MIDI streaming
+		// bulk-in endpoint on this interface we can find.  To distinguish
+		// between the MIDI streaming bulk-in endpoints we want (which carry
+		// actual MIDI data streams) and 'transfer bulk data' endpoints (which
+		// are used to implement features like Downloadable Samples that we
+		// don't care about), we'll look for an immediately-accompanying
+		// class-specific endpoint descriptor.
+		TUSBAudioEndpointDescriptor *pEndpointDesc;
+		while ((pEndpointDesc = (TUSBAudioEndpointDescriptor *) USBDeviceGetDescriptor (&pThis->m_USBDevice, DESCRIPTOR_ENDPOINT)) != 0)
+		{
+			if (   (pEndpointDesc->bEndpointAddress & 0x80) != 0x80		// Input EP
+				|| (pEndpointDesc->bmAttributes     & 0x3F) != 0x02)	// Bulk EP
+			{
+				continue;
+			}
+
+			TUSBMIDIStreamingEndpointDescriptor *pMIDIDesc =
+				(TUSBMIDIStreamingEndpointDescriptor *) USBDeviceGetDescriptor (&pThis->m_USBDevice, DESCRIPTOR_CS_ENDPOINT);
+			if (   pMIDIDesc == 0
+				|| (u8 *)pEndpointDesc + pEndpointDesc->bLength != (u8 *)pMIDIDesc)
+			{
+				continue;
+			}
+
+			assert (pThis->m_pEndpointIn == 0);
+			pThis->m_pEndpointIn = malloc (sizeof (TUSBEndpoint));
+			assert (pThis->m_pEndpointIn != 0);
+
+			pThis->m_usBufferSize = pEndpointDesc->wMaxPacketSize;
+			pThis->m_usBufferSize -= pEndpointDesc->wMaxPacketSize % EVENT_PACKET_SIZE;
+			assert (pThis->m_pPacketBuffer == 0);
+			pThis->m_pPacketBuffer = malloc (pThis->m_usBufferSize);
+			assert (pThis->m_pPacketBuffer != 0);
+
+			USBEndpoint2 (pThis->m_pEndpointIn, &pThis->m_USBDevice, (TUSBEndpointDescriptor *) pEndpointDesc);
+		}
+	}
+
+	if (pThis->m_pEndpointIn == 0)
+	{
+		USBDeviceConfigurationError (&pThis->m_USBDevice, FromMIDI);
+
+		return FALSE;
+	}
+
+	if (!USBDeviceConfigure (&pThis->m_USBDevice))
+	{
+		LogWrite (FromMIDI, LOG_ERROR, "Cannot set configuration");
+
+		return FALSE;
+	}
+
+	TString DeviceName;
+	String (&DeviceName);
+	StringFormat (&DeviceName, "umidi%u", s_nDeviceNumber++);
+	DeviceNameServiceAddDevice (DeviceNameServiceGet (), StringGet (&DeviceName), pThis, FALSE);
+
+	_String(&DeviceName);
+
+	return USBMIDIDeviceStartRequest (pThis);
+}
+
+void USBMIDIDeviceRegisterPacketHandler (TUSBMIDIDevice *pThis, TMIDIPacketHandler *pPacketHandler)
+{
+	assert (pThis != 0);
+	assert (pPacketHandler != 0);
+	pThis->m_pPacketHandler = pPacketHandler;
+}
+
+boolean USBMIDIDeviceStartRequest (TUSBMIDIDevice *pThis)
+{
+	assert (pThis != 0);
+
+	assert (pThis->m_pEndpointIn != 0);
+	assert (pThis->m_pPacketBuffer != 0);
+
+	assert (pThis->m_pURB == 0);
+	pThis->m_pURB = malloc (sizeof (TUSBRequest));
+	assert (pThis->m_pURB != 0);
+	USBRequest (pThis->m_pURB, pThis->m_pEndpointIn, pThis->m_pPacketBuffer, pThis->m_usBufferSize, 0);
+	USBRequestSetCompletionRoutine (pThis->m_pURB, USBMIDIDeviceCompletionRoutine, 0, pThis);
+
+	return DWHCIDeviceSubmitAsyncRequest (USBDeviceGetHost (&pThis->m_USBDevice), pThis->m_pURB);
+}
+
+void USBMIDIDeviceCompletionRoutine (TUSBRequest *pURB, void *pParam, void *pContext)
+{
+	TUSBMIDIDevice *pThis = (TUSBMIDIDevice *) pContext;
+	assert (pThis != 0);
+
+	assert (pURB != 0);
+	assert (pThis->m_pURB == pURB);
+
+	if (   USBRequestGetStatus (pURB) != 0
+		&& USBRequestGetResultLength (pURB) % EVENT_PACKET_SIZE == 0)
+	{
+		assert (pThis->m_pPacketBuffer != 0);
+
+		u8 *pEnd = pThis->m_pPacketBuffer + USBRequestGetResultLength(pURB);
+		for (u8 *pPacket = pThis->m_pPacketBuffer; pPacket < pEnd; pPacket += EVENT_PACKET_SIZE)
+		{
+			// Follow the Linux driver's example and ignore packets with Cable
+			// Number == Code Index Number == 0, which some devices seem to
+			// generate as padding in spite of their status as reserved.
+			if (pPacket[0] != 0)
+			{
+				unsigned nCable = pPacket[0] >> 4;
+				unsigned nLength = cin_to_length[pPacket[0] & 0xf];
+				pThis->m_pPacketHandler(nCable, nLength, &pPacket[1]);
+			}
+		}
+	}
+
+	_USBRequest (pThis->m_pURB);
+	free (pThis->m_pURB);
+	pThis->m_pURB = 0;
+
+	USBMIDIDeviceStartRequest (pThis);
+}

--- a/lib/uspilibrary.c
+++ b/lib/uspilibrary.c
@@ -55,6 +55,8 @@ int USPiInitialize (void)
 
 	s_pLibrary->pUMouse1 = (TUSBMouseDevice *) DeviceNameServiceGetDevice (DeviceNameServiceGet (), "umouse1", FALSE);
 
+	s_pLibrary->pMIDI1 = (TUSBMIDIDevice *) DeviceNameServiceGetDevice (DeviceNameServiceGet (), "umidi1", FALSE);
+
 	for (unsigned i = 0; i < MAX_DEVICES; i++)
 	{
 		TString DeviceName;
@@ -264,6 +266,19 @@ const USPiGamePadState *USPiGamePadGetStatus (unsigned nDeviceIndex)
 	USBGamePadDeviceGetReport (s_pLibrary->pUPAD[nDeviceIndex]);
 
 	return &s_pLibrary->pUPAD[nDeviceIndex]->m_State;
+}
+
+int USPiMIDIAvailable (void)
+{
+	assert (s_pLibrary != 0);
+	return s_pLibrary->pMIDI1 != 0;
+}
+
+void USPiMIDIRegisterPacketHandler (TUSPiMIDIPacketHandler *pPacketHandler)
+{
+	assert (s_pLibrary != 0);
+	assert (s_pLibrary->pMIDI1 != 0);
+	USBMIDIDeviceRegisterPacketHandler (s_pLibrary->pMIDI1, pPacketHandler);
 }
 
 int USPiDeviceGetInformation (unsigned nClass, unsigned nDeviceIndex, TUSPiDeviceInformation *pInfo)

--- a/sample/midi/Makefile
+++ b/sample/midi/Makefile
@@ -1,0 +1,12 @@
+#
+# Makefile
+#
+
+USPIHOME   = ../..
+
+OBJS	= main.o
+
+LIBS	= $(USPIHOME)/lib/libuspi.a \
+	  $(USPIHOME)/env/lib/libuspienv.a
+
+include ../Rules.mk

--- a/sample/midi/main.c
+++ b/sample/midi/main.c
@@ -1,0 +1,81 @@
+//
+// main.c
+//
+#include <uspienv.h>
+#include <uspi.h>
+#include <uspios.h>
+#include <uspienv/util.h>
+
+static const char FromSample[] = "sample";
+
+#define MIDI_NOTE_OFF	0b1000
+#define MIDI_NOTE_ON	0b1001
+
+static void PacketHandler (unsigned nCable, unsigned nLength, u8 *pPacket)
+{
+	// The packet contents are just normal MIDI data - see
+	// https://www.midi.org/specifications/item/table-1-summary-of-midi-message
+
+	u8 ucStatus = pPacket[0];
+	u8 ucChannel = ucStatus & 0xf;
+	u8 ucType = ucStatus >> 4;
+
+	switch (ucType)
+	{
+	case MIDI_NOTE_OFF:
+	case MIDI_NOTE_ON:
+	{
+		u8 ucKey = pPacket[1], ucVelocity = pPacket[2];
+		LogWrite(FromSample,
+				 LOG_NOTICE,
+				 "Note %u %s! (velocity %u, cable %u, channel %u)",
+				 ucKey,
+				 ucType == MIDI_NOTE_OFF ? "off" : "on",
+				 ucVelocity,
+				 nCable,
+				 ucChannel);
+		break;
+	}
+	default:
+		LogWrite(FromSample, LOG_NOTICE, "Other MIDI message type! (cable %u, channel %u)", nCable, ucChannel);
+		break;
+	}
+}
+
+int main (void)
+{
+	if (!USPiEnvInitialize ())
+	{
+		return EXIT_HALT;
+	}
+
+	if (!USPiInitialize ())
+	{
+		LogWrite (FromSample, LOG_ERROR, "Cannot initialize USPi");
+
+		USPiEnvClose ();
+
+		return EXIT_HALT;
+	}
+
+	if (!USPiMIDIAvailable ())
+	{
+		LogWrite (FromSample, LOG_ERROR, "MIDI device not found");
+
+		USPiEnvClose ();
+
+		return EXIT_HALT;
+	}
+
+	USPiMIDIRegisterPacketHandler (PacketHandler);
+
+	LogWrite (FromSample, LOG_NOTICE, "Play!");
+
+	// just wait and turn the rotor
+	for (unsigned nCount = 0; 1; nCount++)
+	{
+		ScreenDeviceRotor (USPiEnvGetScreen (), 0, nCount);
+	}
+
+	return EXIT_HALT;
+}


### PR DESCRIPTION
This patch adds support for the USB-MIDI device class (for musical instruments) as specified by http://www.usb.org/developers/docs/devclass_docs/midi10.pdf.  The class driver is based on the mouse and gamepad drivers - all it does is find the right bulk-in endpoint at configuration time and read MIDI packets from it.

I did have to make some slight modifications to the core library to get it working - endpoint descriptors for devices in the audio class annoyingly extend the standard USB endpoint descriptors with two extra members (see page 25 of the linked USB-MIDI spec), so various assertions about the size of endpoint descriptors needed to be relaxed.  The audio class (and MIDI within it) also add a number of other class-specific descriptors.

I've tried to be consistent with the rest of the codebase with respect to style, but if I've gotten any of it wrong please let me know.  Thanks for the fantastic library!